### PR TITLE
WDL feature: Adding tsv headers to lift.files

### DIFF
--- a/wdl/lift.wdl
+++ b/wdl/lift.wdl
@@ -34,10 +34,10 @@ task liftfile {
 
 workflow lift {
     File files
-    Array[String] fs= read_lines(files)
+    Array[Array[String]] fs= read_tsv(files)
     scatter (f in fs) {
         call liftfile {
-            input:  f=f
+            input:  f=f[0], chr_col=f[1], pos_col=f[2], ref_col=f[3], alt_col=f[4]
         }
     }
 


### PR DESCRIPTION
## Background
In the wdl, the defaults for chr, pos, ref, alt are passed on with: 
```
  "lift.liftfile.ref_col": "a1",
  "lift.liftfile.chr_col": "chr",
  "lift.liftfile.pos_col": "pos",
  "lift.liftfile.alt_col": "a2"
```
But files listed in `list.files` can have varying chr, pos, ref, alt headers. 

## Solution
I changed the wdl such that `lift.files` has four more columns: `filename, chr, pos, ref, alt` (no header)

@Fedja I wanted to change the workflow (line 40) to something like this, so that you can either pass on default args or use the extra 4 columns.
```
## use default args
if (length(f) == 1) {
      call liftfile {
            input:  f=f
        }
}
## use extra 4 columns
if (length(f) > 1) {
      call liftfile as liftfile.custom {
            input:  f=f[0], chr_col=f[1], pos_col=f[2], ref_col=f[3], alt_col=f[4]
        }
}
```
but didn't work. can you spot the bug?