### PR TITLE
Check for another variant in same position

### DIFF
--- a/scripts/meta_analysis.py
+++ b/scripts/meta_analysis.py
@@ -500,7 +500,6 @@ class Study:
         
         input:
             variantlist: list of VariantData objects
-            right: if True, add variants in list to the end of deque. If False, add in the beginning
         output:
             p-value
         '''

--- a/scripts/meta_analysis.py
+++ b/scripts/meta_analysis.py
@@ -262,17 +262,6 @@ class VariantData:
 
         return False
 
-    def is_perfect_match(self, other:'VariantData') -> bool:
-        """
-            Checks if this VariantData is exactly the same variant
-
-            input:
-                other: A VariantData object to compare to
-            output:
-                True if perfect match False if not
-        """
-        return(self.chr == other.chr and self.pos == other.pos and self.ref == other.ref and self.alt == other.alt)
-
     @property
     def z_score(self):
         '''
@@ -577,7 +566,7 @@ def get_next_variant( studies : List[Study]) -> List[VariantData]:
         added=False
         for v in reversed(dats[i]):
             if not added:
-                if v.is_perfect_match(first):
+                if v == first:
                     res.append(v)
                     added=True
                 else:
@@ -585,7 +574,7 @@ def get_next_variant( studies : List[Study]) -> List[VariantData]:
                     if (first.chr == v.chr and first.pos == v.pos):
                         next_vars = s.get_next_data()
                         for j,var in reversed(list(enumerate(next_vars))):
-                            if var.is_perfect_match(first):
+                            if var == first:
                                 res.append(var)
                                 added=True
                                 del next_vars[j]

--- a/scripts/meta_analysis.py
+++ b/scripts/meta_analysis.py
@@ -431,7 +431,7 @@ class Study:
             if len(vars)==0 or ( vars[0].chr == v.chr and vars[0].pos == v.pos  ):
                 added=False
                 for v_ in vars:
-                    if v.is_equal(v_):
+                    if v == v_:
                         print('ALREADY ADDED FOR STUDY ' + self.name + ': ' + str(v))
                         added=True
                 if not added:

--- a/scripts/meta_analysis.py
+++ b/scripts/meta_analysis.py
@@ -436,7 +436,7 @@ class Study:
                 added=False
                 for v_ in vars:
                     if v == v_:
-                        print('ALREADY ADDED FOR STUDY ' + self.name + ': ' + str(v))
+                        print('ALREADY ADDED FOR STUDY ' + self.name + ': ' + str(v), file=sys.stderr)
                         added=True
                 if not added:
                     vars.append(v )


### PR DESCRIPTION
When the right study has more than one variant in the same position and only the first one is assigned to it's `future`, the following variant is not checked even though it could be an exact match (ref & alt) to the left study's variant. This PR fixes this (#27). Now the checking is forced, and the deque `future` is utilized more to hold the variants.