### PR TITLE
Add filter for af difference & don't flip indels by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ Tools for doing x way meta-analysis
 ## Variant matching across studies
 
 Variants are matched using chr pos ref and alt. For this reason all 37 build results need to first be lifted over to 38.
-<https://github.com/FINNGEN/commons/tree/master/liftover> can be used to liftover results first if needed.
+[lift.wdl](wdl/lift.wdl) can be used to liftover results first if needed.
 
 IMPORTANT: Studies need to be ordered by chr (1-22, x,y,mt) and position. Chromosome can be indicated with numbers 1-25 or 1-22, X, Y, MT, with or without 'chr' prefix and they will be internally coded to numerical values.
+
+## Munging
+
+Workflow for data munging (liftover, harmonization with GnomAD, general QC) can be run for sumstats prior to meta-analysis: [munge.wdl](wdl/munge.wdl)
 
 ## Running single trait meta-analysis
 
@@ -62,4 +66,4 @@ The configuration file should be a json file with these elements:
 * `variance`: weight z-score from p-value by variance,
 * `inv_var`: regular inverse variance weighted betas meta-analysis.
 
-`inv_var` is recommeneded if betas and variances are comparable. In case of combining data frmo different models (e.g.) linear vs. logistic you should use sample size weighted meta.
+`inv_var` is recommeneded if betas and variances are comparable. In case of combining data from different models (e.g.) linear vs. logistic you should use sample size weighted meta.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Run x-way meta-analysis
 positional arguments:
   config_file           Configuration file
   path_to_res           Result file
-  methods               List of meta-analysis methods to compute separated by
-                        commas.Allowed values [n,inv_var,variance]
+  methods               List of meta-analysis methods to compute separated by commas. Allowed values [n,inv_var,variance]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -37,6 +36,7 @@ optional arguments:
                         Do pairwise meta-analysis with the first given study
   --dont_allow_space    Do not allow space as field delimiter
   --chrom CHROM         Restrict to given chromosome
+  --flip_indels         Try variant aligning by flipping indels also. By default indels are not flipped
 ```
 
 The configuration file should be a json file with these elements:

--- a/scripts/harmonize.py
+++ b/scripts/harmonize.py
@@ -201,8 +201,9 @@ def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, bet
                     diffs.append(diff)
                     fcs.append(fc)
 
-            best_diff = 1
+            best_diff = -1
             if len(equal) > 0:
+                best_diff = 1
                 for i,diff in enumerate(diffs):
                     if diff < best_diff or (diff == best_diff and equal[i].ref == var.ref and equal[i].alt == var.alt):
                         best_diff = diff

--- a/scripts/harmonize.py
+++ b/scripts/harmonize.py
@@ -201,7 +201,7 @@ def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, bet
                     diffs.append(diff)
                     fcs.append(fc)
 
-            best_diff = 1e9
+            best_diff = 1
             if len(equal) > 0:
                 for i,diff in enumerate(diffs):
                     if diff < best_diff or (diff == best_diff and equal[i].ref == var.ref and equal[i].alt == var.alt):
@@ -212,7 +212,7 @@ def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, bet
                 var.af_fc = fcs[best_diff_idx] if fcs[best_diff_idx] != 1e9 else None
                 var.gnomad_filt = equal[best_diff_idx].filt
 
-            if (not require_gnomad or len(equal) > 0) and best_diff < gnomad_max_abs_diff:
+            if (not require_gnomad or len(equal) > 0) and best_diff <= gnomad_max_abs_diff:
                 print(var)
             
 def run():

--- a/scripts/harmonize.py
+++ b/scripts/harmonize.py
@@ -201,8 +201,8 @@ def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, bet
                     diffs.append(diff)
                     fcs.append(fc)
 
+            best_diff = 1e9
             if len(equal) > 0:
-                best_diff = 1e9
                 for i,diff in enumerate(diffs):
                     if diff < best_diff or (diff == best_diff and equal[i].ref == var.ref and equal[i].alt == var.alt):
                         best_diff = diff

--- a/scripts/harmonize.py
+++ b/scripts/harmonize.py
@@ -134,10 +134,13 @@ class VariantData(Variant):
         cols.extend([format_num(self.gnomad_af, 3), format_num(self.af_fc, 3), self.gnomad_filt])
         return '\t'.join(cols)
 
-def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, beta_col, require_gnomad, passing_only, gnomad_min_an):
+def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, beta_col, require_gnomad, passing_only, gnomad_min_an, gnomad_max_abs_diff):
 
     if gnomad_min_an is None:
         gnomad_min_an = -1
+    
+    if gnomad_max_abs_diff is None:
+        gnomad_max_abs_diff = 1
 
     required_cols = [chr_col, pos_col, ref_col, alt_col, af_col, beta_col]
     
@@ -209,7 +212,7 @@ def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, bet
                 var.af_fc = fcs[best_diff_idx] if fcs[best_diff_idx] != 1e9 else None
                 var.gnomad_filt = equal[best_diff_idx].filt
 
-            if not require_gnomad or len(equal) > 0:
+            if (not require_gnomad or len(equal) > 0) and best_diff < gnomad_max_abs_diff:
                 print(var)
             
 def run():
@@ -225,6 +228,7 @@ def run():
     parser.add_argument('--require_gnomad', action='store_true', help='Filter out variants not in gnomAD')
     parser.add_argument('--passing_only', action='store_true', help='Filter out non-passing variants in gnomAD')
     parser.add_argument('--gnomad_min_an', type=int, action='store', help='Minimum AN in gnomAD')
+    parser.add_argument('--gnomad_max_abs_diff', type=float, action='store', help='Maximum absolute difference between variant and gnomAD AF')
     args = parser.parse_args()
     harmonize(file_in = args.file_in,
               file_ref = args.file_ref,
@@ -236,7 +240,8 @@ def run():
               beta_col = args.beta_col,
               require_gnomad = args.require_gnomad,
               passing_only = args.passing_only,
-              gnomad_min_an = args.gnomad_min_an)
+              gnomad_min_an = args.gnomad_min_an,
+              gnomad_max_abs_diff = args.gnomad_max_abs_diff)
     
 if __name__ == '__main__':
     run()

--- a/scripts/harmonize.py
+++ b/scripts/harmonize.py
@@ -192,7 +192,7 @@ def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, bet
             fcs = []
             for r in ref_vars:
                 if var.equalize_to(r) and (not passing_only or r.filt == 'PASS') and r.an >= gnomad_min_an:
-                    diff = 1e9
+                    diff = 1
                     fc = 1e9
                     if r.af is not None and var.af is not None:
                         diff = abs(var.af - float(r.af))
@@ -203,7 +203,7 @@ def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, bet
 
             best_diff = -1
             if len(equal) > 0:
-                best_diff = 1
+                best_diff = 2
                 for i,diff in enumerate(diffs):
                     if diff < best_diff or (diff == best_diff and equal[i].ref == var.ref and equal[i].alt == var.alt):
                         best_diff = diff

--- a/scripts/harmonize.py
+++ b/scripts/harmonize.py
@@ -136,12 +136,6 @@ class VariantData(Variant):
 
 def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, beta_col, require_gnomad, passing_only, gnomad_min_an, gnomad_max_abs_diff):
 
-    if gnomad_min_an is None:
-        gnomad_min_an = -1
-    
-    if gnomad_max_abs_diff is None:
-        gnomad_max_abs_diff = 1
-
     required_cols = [chr_col, pos_col, ref_col, alt_col, af_col, beta_col]
     
     fp_ref = gzip.open(file_ref, 'rt')
@@ -231,8 +225,8 @@ def run():
     parser.add_argument('--beta_col', action='store', type=str, default='beta', help='Beta column')
     parser.add_argument('--require_gnomad', action='store_true', help='Filter out variants not in gnomAD')
     parser.add_argument('--passing_only', action='store_true', help='Filter out non-passing variants in gnomAD')
-    parser.add_argument('--gnomad_min_an', type=int, action='store', help='Minimum AN in gnomAD')
-    parser.add_argument('--gnomad_max_abs_diff', type=float, action='store', help='Maximum absolute difference between variant and gnomAD AF')
+    parser.add_argument('--gnomad_min_an', action='store', type=int, default=0, help='Minimum AN in gnomAD')
+    parser.add_argument('--gnomad_max_abs_diff', action='store', type=float, default=1.0, help='Maximum absolute difference between variant and gnomAD AF')
     args = parser.parse_args()
     harmonize(file_in = args.file_in,
               file_ref = args.file_ref,

--- a/scripts/harmonize.py
+++ b/scripts/harmonize.py
@@ -194,7 +194,7 @@ def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, bet
             diffs = []
             fcs = []
             for r in ref_vars:
-                if var.equalize_to(r) and (not passing_only or r.filt == 'PASS') and r.an >= gnomad_min_an:
+                if var == r and (not passing_only or r.filt == 'PASS') and r.an >= gnomad_min_an:
                     diff = 1
                     fc = 1e9
                     if r.af is not None and var.af is not None:

--- a/scripts/harmonize.py
+++ b/scripts/harmonize.py
@@ -166,12 +166,14 @@ def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, bet
                               extra_cols = [s[h_idx[extra_col]] for extra_col in extra_cols])
             ref_vars = []
             while ref_has_lines and ref_chr < var.chr or (ref_chr == var.chr and ref_pos < var.pos):
-                ref_line = fp_ref.readline().strip().split('\t')
-                try:
+                ref_line = fp_ref.readline()
+                if ref_line != '':
+                    r = ref_line.strip().split('\t')
                     ref_chr = int(ref_line[ref_h_idx['#chr']])
                     ref_pos = int(ref_line[ref_h_idx['pos']])
-                except ValueError:
+                else:
                     ref_has_lines = False
+
             while ref_has_lines and ref_chr == var.chr and ref_pos == var.pos:
                 ref_vars.append(Variant(chr = ref_chr,
                                         pos = ref_pos,
@@ -180,11 +182,12 @@ def harmonize(file_in, file_ref, chr_col, pos_col, ref_col, alt_col, af_col, bet
                                         af = ref_line[ref_h_idx['af_alt']],
                                         filt = ref_line[ref_h_idx['filter']],
                                         an = ref_line[ref_h_idx['an']]))
-                ref_line = fp_ref.readline().strip().split('\t')
-                try:
+                ref_line = fp_ref.readline()
+                if ref_line != '':
+                    r = ref_line.strip().split('\t')
                     ref_chr = int(ref_line[ref_h_idx['#chr']])
                     ref_pos = int(ref_line[ref_h_idx['pos']])
-                except ValueError:
+                else:
                     ref_has_lines = False
 
             equal = []

--- a/scripts/meta_analysis.py
+++ b/scripts/meta_analysis.py
@@ -252,6 +252,7 @@ class VariantData:
 
         return False
 
+    @property
     def z_score(self):
         '''
             Lazy compute unsigned z-score
@@ -260,6 +261,7 @@ class VariantData:
             self.z_scr = math.sqrt(chi2.isf(self.pval, df=1))
         return self.z_scr
 
+    @property
     def is_indel(self):
         if self.indel is None:
             self.indel = len(self.ref)>1 or len(self.alt)>1

--- a/scripts/meta_analysis.py
+++ b/scripts/meta_analysis.py
@@ -162,9 +162,6 @@ def flip_strand( allele):
 def is_symmetric(a1, a2):
     return (a1=="A" and a2=="T") or (a1=="T" and a2=="A") or (a1=="C" and a2=="G") or (a1=="G" and a2=="C")
 
-def is_indel(a1, a2):
-    return len(a1)>1 or len(a2)>1
-
 
 class VariantData:
 
@@ -176,7 +173,7 @@ class VariantData:
         self.beta = beta
         self.pval = pval
         self.z_scr = None
-        self.is_indel = None
+        self.indel = None
         try:
             self.se = float(se) if se is not None  else None
         except ValueError:
@@ -255,7 +252,6 @@ class VariantData:
 
         return False
 
-    @property
     def z_score(self):
         '''
             Lazy compute unsigned z-score
@@ -264,16 +260,10 @@ class VariantData:
             self.z_scr = math.sqrt(chi2.isf(self.pval, df=1))
         return self.z_scr
 
-    @property
     def is_indel(self):
-        """Checks if variant is indel
-
-        Returns:
-            True if variant is indel else False
-        """
-
-        self.is_indel = len(self.ref)>1 or len(self.alt)>1 if self.is_indel is None else self.is_indel
-        return self.is_indel
+        if self.indel is None:
+            self.indel = len(self.ref)>1 or len(self.alt)>1
+        return self.indel
 
     def __str__(self):
         return "chr:{} pos:{} ref:{} alt:{} beta:{} pval:{} se:{} ".format(self.chr, self.pos, self.ref, self.alt, self.beta, self.pval, self.se)

--- a/scripts/meta_analysis.py
+++ b/scripts/meta_analysis.py
@@ -613,11 +613,10 @@ def run():
         Second parameter should be a path to (empty/not existing) directory where the data should be stored
     '''
 
-    parser = argparse.ArgumentParser(description="Run x-way meta-analysis")
+    parser = argparse.ArgumentParser(description='Run x-way meta-analysis')
     parser.add_argument('config_file', action='store', type=str, help='Configuration file ')
     parser.add_argument('path_to_res', action='store', type=str, help='Result file')
-    parser.add_argument('methods', action='store', type=str, help='List of meta-analysis methods to compute separated by commas.'
-            + 'Allowed values [n,inv_var,variance]', default="inv_var")
+    parser.add_argument('methods', action='store', type=str, help='List of meta-analysis methods to compute separated by commas. Allowed values [n,inv_var,variance]', default='inv_var')
 
     parser.add_argument('--not_quiet', action='store_false', dest='quiet', help='Print matching variants to stdout')
     parser.add_argument('--leave_one_out', action='store_true', help='Do leave-one-out meta-analysis')
@@ -625,7 +624,7 @@ def run():
     parser.add_argument('--pairwise_with_first', action='store_true', help='Do pairwise meta-analysis with the first given study')
     parser.add_argument('--dont_allow_space', action='store_true', help='Do not allow space as field delimiter')
     parser.add_argument('--chrom', action='store', type=str, help='Restrict to given chromosome')
-    parser.add_argument('--flip_indels', action='store_true', help='Try variant aligning by flipping indels also.')
+    parser.add_argument('--flip_indels', action='store_true', help='Try variant aligning by flipping indels also. By default indels are not flipped')
 
     args = parser.parse_args()
 

--- a/scripts/meta_analysis.py
+++ b/scripts/meta_analysis.py
@@ -162,6 +162,9 @@ def flip_strand( allele):
 def is_symmetric(a1, a2):
     return (a1=="A" and a2=="T") or (a1=="T" and a2=="A") or (a1=="C" and a2=="G") or (a1=="G" and a2=="C")
 
+def is_indel(a1, a2):
+    return len(a1)>1 or len(a2)>1
+
 
 class VariantData:
 
@@ -202,6 +205,9 @@ class VariantData:
 
             if self.ref== other.ref and self.alt == other.alt :
                 return True
+            
+            if is_indel(other.ref, other.alt):
+                return False
 
             if is_symmetric( other.ref, other.alt ):
                 ## never strandflip symmetrics. Assumed to be aligned.
@@ -231,7 +237,10 @@ class VariantData:
             flip_alt =  flip_strand(other.alt)
 
             if self.ref== other.ref and self.alt == other.alt :
-                    return True
+                return True
+            
+            if is_indel(other.ref, other.alt):
+                return False
 
             if is_symmetric( other.ref, other.alt ):
                 ## never strandflip symmetrics. Assumed to be aligned.

--- a/scripts/meta_analysis.py
+++ b/scripts/meta_analysis.py
@@ -221,10 +221,7 @@ class VariantData:
 
             if is_symmetric(other.ref, other.alt):
                 ## never strandflip symmetrics. Assumed to be aligned.
-                if self.ref == other.ref and self.alt == other.alt:
-                    return True
-                elif self.ref == other.alt and self.alt == other.ref:
-                    return True
+                return False
 
             elif (self.ref == other.alt and self.alt == other.ref) :
                 if equalize:

--- a/scripts/meta_analysis.py
+++ b/scripts/meta_analysis.py
@@ -176,6 +176,7 @@ class VariantData:
         self.beta = beta
         self.pval = pval
         self.z_scr = None
+        self.is_indel = None
         try:
             self.se = float(se) if se is not None  else None
         except ValueError:
@@ -193,80 +194,63 @@ class VariantData:
                   or (self.chr < other.chr)
                )
 
-    def is_equal(self, other:'VariantData') -> bool:
-        """
-            Checks if this VariantData is the same variant (possibly different strand or ordering of alleles)
-            returns: true if the same false if not
+    def is_equal(self, other: 'VariantData', equalize: bool = False, flip_indels: bool = False) -> bool:
+        """Checks if two variants are equal
+
+        Checks if this VariantData is the same variant as given other variant (possibly different strand or ordering of alleles).
+        
+        Args:
+            other:
+                Variant as VariantData object to compare this variant to.
+            equalize:
+                If True changes this variant's alleles and beta accordingly.
+            flip_indels:
+                If True will try matching indels with flipping.
+
+        Returns:
+            True if the same or False if not the same variant.
         """
 
         if (self.chr == other.chr and self.pos == other.pos):
-            flip_ref =  flip_strand(other.ref)
-            flip_alt =  flip_strand(other.alt)
 
-            if self.ref== other.ref and self.alt == other.alt :
+            if self.ref == other.ref and self.alt == other.alt :
                 return True
             
-            if is_indel(other.ref, other.alt):
+            if not flip_indels and self.is_indel:
                 return False
+            
+            flip_ref = flip_strand(other.ref)
+            flip_alt = flip_strand(other.alt)
 
-            if is_symmetric( other.ref, other.alt ):
+            if is_symmetric(other.ref, other.alt):
                 ## never strandflip symmetrics. Assumed to be aligned.
                 if self.ref == other.ref and self.alt == other.alt:
                     return True
                 elif self.ref == other.alt and self.alt == other.ref:
+                    if equalize:
+                        self.beta = -1 * self.beta if self.beta is not None else None
+                        t = self.alt
+                        self.alt = self.ref
+                        self.ref = t
                     return True
 
             elif (self.ref == other.alt and self.alt == other.ref) :
-                return True
-            elif (self.ref == flip_ref and self.alt==flip_alt):
-                return True
-            elif (self.ref == flip_alt and self.alt==flip_ref):
-                return True
-
-        return False
-
-    def equalize_to(self, other:'VariantData') -> bool:
-        """
-            Checks if this VariantData is the same variant as given other variant (possibly different strand or ordering of alleles)
-            If it is, changes this variant's alleles and beta accordingly
-            returns: true if the same (flips effect direction and ref/alt alleles if necessary) or false if not the same variant
-        """
-
-        if (self.chr == other.chr and self.pos == other.pos):
-            flip_ref =  flip_strand(other.ref)
-            flip_alt =  flip_strand(other.alt)
-
-            if self.ref== other.ref and self.alt == other.alt :
-                return True
-            
-            if is_indel(other.ref, other.alt):
-                return False
-
-            if is_symmetric( other.ref, other.alt ):
-                ## never strandflip symmetrics. Assumed to be aligned.
-                if self.ref == other.ref and self.alt == other.alt:
-                    return True
-                elif self.ref == other.alt and self.alt == other.ref:
+                if equalize:
                     self.beta = -1 * self.beta if self.beta is not None else None
                     t = self.alt
                     self.alt = self.ref
                     self.ref = t
-                    return True
-
-            elif (self.ref == other.alt and self.alt == other.ref) :
-                self.beta = -1 * self.beta if self.beta is not None else None
-                t = self.alt
-                self.alt = self.ref
-                self.ref = t
                 return True
-            elif (self.ref == flip_ref and self.alt==flip_alt):
-                self.ref = flip_strand(self.ref)
-                self.alt = flip_strand(self.alt)
+            elif (self.ref == flip_ref and self.alt == flip_alt):
+                if equalize:
+                    self.ref = flip_strand(self.ref)
+                    self.alt = flip_strand(self.alt)
                 return True
-            elif (self.ref == flip_alt and self.alt==flip_ref):
-                self.beta = -1 * self.beta if self.beta is not None else None
-                self.ref =flip_strand(self.alt)
-                self.alt = flip_strand(self.ref)
+            elif (self.ref == flip_alt and self.alt == flip_ref):
+                if equalize:
+                    self.beta = -1 * self.beta if self.beta is not None else None
+                    self.ref = flip_strand(self.alt)
+                    self.alt = flip_strand(self.ref)
                 return True
 
         return False
@@ -279,6 +263,17 @@ class VariantData:
         if self.z_scr is None:
             self.z_scr = math.sqrt(chi2.isf(self.pval, df=1))
         return self.z_scr
+
+    @property
+    def is_indel(self):
+        """Checks if variant is indel
+
+        Returns:
+            True if variant is indel else False
+        """
+
+        self.is_indel = len(self.ref)>1 or len(self.alt)>1 if self.is_indel is None else self.is_indel
+        return self.is_indel
 
     def __str__(self):
         return "chr:{} pos:{} ref:{} alt:{} beta:{} pval:{} se:{} ".format(self.chr, self.pos, self.ref, self.alt, self.beta, self.pval, self.se)
@@ -295,7 +290,7 @@ class Study:
 
     OPTIONAL_FIELDS = {"se":str}
 
-    def __init__(self, conf, chrom=None, dont_allow_space=False):
+    def __init__(self, conf, chrom=None, dont_allow_space=False, flip_indels=False):
         '''
         chrom: a chromosome to limit to or None if all chromosomes
         dont_allow_space: boolean, don't treat space as field delimiter (only tab)
@@ -303,6 +298,7 @@ class Study:
         self.conf = conf
         self.chrom = chrord[chrom] if chrom is not None else None
         self.dont_allow_space = dont_allow_space
+        self.flip_indels = flip_indels
         self.future = deque()
         self.eff_size = None
         self.z_scr = None
@@ -492,7 +488,7 @@ class Study:
             return None
 
         for i,v in enumerate(otherdats):
-            if v.equalize_to(dat):
+            if v.is_equal(dat, equalize=True, flip_indels=self.flip_indels):
                 del otherdats[i]
                 self.put_back(otherdats)
                 return v
@@ -515,14 +511,14 @@ class Study:
         self.future.extendleft(variantlist)
 
 
-def get_studies(conf:str, chrom, dont_allow_space) -> List[Study]:
+def get_studies(conf:str, chrom, dont_allow_space, flip_indels) -> List[Study]:
     """
         Reads json configuration and returns studies in the meta
     """
 
     studies_conf = json.load(open(conf,'r'))
 
-    return [ Study(s, chrom, dont_allow_space) for s in studies_conf["meta"]]
+    return [ Study(s, chrom, dont_allow_space, flip_indels) for s in studies_conf["meta"]]
 
 def do_meta(study_list: List[ Tuple[Study, VariantData]], methods: List[str], is_het_test) -> List[Tuple] :
     '''
@@ -589,12 +585,12 @@ def get_next_variant( studies : List[Study]) -> List[VariantData]:
                 del dats[i][j]
                 s.put_back(dats[i])
                 break
-            if not v.is_equal(first):
+            if not v.is_equal(first, equalize=False, flip_indels=s.flip_indels):
                 s.put_back([v])
                 del dats[i][j]
         if not added:
             for j,v in reversed(list(enumerate(dats[i]))):
-                if v.equalize_to(first):
+                if v.is_equal(first, equalize=True, flip_indels=s.flip_indels):
                     res.append(v)
                     added=True
                     del dats[i][j]
@@ -637,10 +633,11 @@ def run():
     parser.add_argument('--pairwise_with_first', action='store_true', help='Do pairwise meta-analysis with the first given study')
     parser.add_argument('--dont_allow_space', action='store_true', help='Do not allow space as field delimiter')
     parser.add_argument('--chrom', action='store', type=str, help='Restrict to given chromosome')
+    parser.add_argument('--flip_indels', action='store_true', help='Try variant aligning by flipping indels also.')
 
     args = parser.parse_args()
 
-    studs = get_studies(args.config_file, args.chrom, args.dont_allow_space)
+    studs = get_studies(args.config_file, args.chrom, args.dont_allow_space, args.flip_indels)
 
     methods = []
 

--- a/wdl/munge.json
+++ b/wdl/munge.json
@@ -17,7 +17,7 @@
     "munge.lift_postprocess.docker": "eu.gcr.io/finngen-refinery-dev/bioinformatics:0.7",
     "munge.harmonize.docker": "gcr.io/finngen-refinery-dev/meta:b33b946",
     "munge.harmonize.gnomad_ref": "gs://gnomad3/genomes_3.0/ref/filter/gnomad_v3_b38_ref_nfe.gz",
-    "munge.harmonize.options": "",
+    "munge.harmonize.options": "--pre_aligned",
     "munge.plot.docker": "gcr.io/finngen-refinery-dev/meta:b33b946",
     "munge.plot.loglog_ylim": 20
 }


### PR DESCRIPTION
* Added option to filter for af difference during harmonization with gnomad
* by default, indels are not flipped in meta-analysis

There's now a new flag `--flip_indels` to enable flipping of indels during meta-analysis to try aligning variants. It was observed during analysis of 3-way meta results that the indel flipping and matching can cause mismatching variants aligned.

Also a minor structural change to meta_analysis.py was to combine functions `is_equal` and `equalize_to` since they were pretty similar.