### PR TITLE
Disable sorting in liftover call

### DIFF
--- a/wdl/lift.wdl
+++ b/wdl/lift.wdl
@@ -168,7 +168,8 @@ task lift {
             --REJECT rejected_variants.vcf \
             -R ~{b38_assembly_fasta} \
             --MAX_RECORDS_IN_RAM 500000 \
-            --RECOVER_SWAPPED_REF_ALT true
+            --RECOVER_SWAPPED_REF_ALT true \
+            --DISABLE_SORT true
 
     >>>
 

--- a/wdl/munge.wdl
+++ b/wdl/munge.wdl
@@ -263,7 +263,8 @@ task lift {
             --REJECT rejected_variants.vcf \
             -R ~{b38_assembly_fasta} \
             --MAX_RECORDS_IN_RAM 500000 \
-            --RECOVER_SWAPPED_REF_ALT true
+            --RECOVER_SWAPPED_REF_ALT true \
+            --DISABLE_SORT true
 
     >>>
 


### PR DESCRIPTION
In the liftover call it's unnecessary to sort the vcf as we have to sort by different columns in the next step (so we can match the lifted positions with the original file more easily).